### PR TITLE
iOS XCode13 fix Undefined symbol

### DIFF
--- a/ios/RNImageHelper.podspec
+++ b/ios/RNImageHelper.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
 
   s.preserve_paths         = 'LICENSE', 'package.json'
   s.source_files           = '**/*.{h,m}'
-  s.dependency             'React'
+  s.dependency             'React-Core'
 end


### PR DESCRIPTION
Undefined symbol: _RCTRegisterModule XCode 13 iOS fix.